### PR TITLE
キャラクター一覧のダミーページを追加

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -16,7 +16,7 @@ const Footer: React.FC = () => {
             <Link href="/terms" className="">
               <a>利用規約</a>
             </Link>
-            <Link href="#" className="">
+            <Link href="/characters" className="">
               <a>キャラクター一覧</a>
             </Link>
             <Link href="#" className="">

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -110,7 +110,7 @@ const Header: React.FC<Props> = ({ mainPageHeader, title }) => {
               </Link>
             </li>
             <li className="border-b md:border-none">
-              <Link href="#">
+              <Link href="/characters">
                 <a className={headerButtonClass}>キャラクター一覧</a>
               </Link>
             </li>

--- a/pages/characters.tsx
+++ b/pages/characters.tsx
@@ -1,0 +1,19 @@
+import { NextPageWithLayout } from 'next'
+
+import Layout from '@/components/layout'
+
+type Props = {}
+
+const Characters: NextPageWithLayout<Props> = ({}) => {
+  return (
+    <div className="mx-10">
+      <h1>Coming Soon...</h1>
+    </div>
+  )
+}
+
+Characters.getLayout = (page) => (
+  <Layout title="キャラクター一覧">{page}</Layout>
+)
+
+export default Characters


### PR DESCRIPTION
## 概要
キャラクター一覧のページが間に合わなかった時用にキャラクター用のダミーページを用意しておく

ref: #1

以下引用

> Twitterに人が集まりそうな時間を考慮して(?)今日の夕方ぐらい(多分18時19時とか)めどに宣伝していこうと思います
それまでにキャラ一覧完成しなければ、工事中にしようと思うので、サクッとで競うであればPRだけ準備しておいてもらえると助かります....

<details>
<summary>スクショ</summary>

![localhost_3000_characters](https://user-images.githubusercontent.com/29667656/187818071-de1db21f-d92c-49a3-8856-4a499a7ab7fd.png)

</details>