### PR TITLE
add GoogleAnalytics(GA4)

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import React, { useState } from 'react'
 
 import firstViewImage from '@/public/sharevox-first-view.png'
+import { GA_ID } from "@/lib/gtag";
 
 type Props = {
   mainPageHeader: boolean
@@ -80,6 +81,24 @@ const Header: React.FC<Props> = ({ mainPageHeader, title }) => {
         <meta name="twitter:title" content="SHAREVOX" />
         <meta name="twitter:description" content={description} />
         <meta name="twitter:domain" content="www.sharevox.app" />
+        
+        {/* Google Analytics */}
+        {GA_ID && (
+             <>
+               <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`} />
+               <script
+                 dangerouslySetInnerHTML={{
+                   __html: `
+                   window.dataLayer = window.dataLayer || [];
+                   function gtag(){dataLayer.push(arguments);}
+                   gtag('js', new Date());
+                   gtag('config', '${GA_ID}', {
+                     page_path: window.location.pathname,
+                   });`,
+                 }}
+               />
+             </>
+           )}
       </Head>
 
       <header className={headerClass}>

--- a/config.ts
+++ b/config.ts
@@ -15,7 +15,7 @@ const config = {
   OFFICIAL_TWITTER_URL: 'https://twitter.com/sharevox_pj',
   DEVELOPER_TWITTER_URL: 'https://twitter.com/y_chan_dev',
   FANBOX_URL: 'https://y-chan.fanbox.cc',
-  GOOGLEANALYTICS_ID: '',
+  GOOGLEANALYTICS_ID: 'G-CBG62PCLQP',
 }
 
 export default config

--- a/config.ts
+++ b/config.ts
@@ -15,6 +15,7 @@ const config = {
   OFFICIAL_TWITTER_URL: 'https://twitter.com/sharevox_pj',
   DEVELOPER_TWITTER_URL: 'https://twitter.com/y_chan_dev',
   FANBOX_URL: 'https://y-chan.fanbox.cc',
+  GOOGLEANALYTICS_ID: '',
 }
 
 export default config

--- a/lib/gtag.tsx
+++ b/lib/gtag.tsx
@@ -1,0 +1,88 @@
+import { useRouter } from 'next/router'
+import Script from 'next/script'
+import { useEffect } from 'react'
+import config from '@/config'
+
+export const GA_ID = config.GOOGLEANALYTICS_ID || ''
+
+// IDが取得できない場合を想定する
+export const existsGaId = GA_ID !== ''
+
+// PVを測定する
+export const pageview = (path: string) => {
+  window.gtag('config', GA_ID, {
+    page_path: path,
+  })
+}
+
+// GAイベントを発火させる
+export const event = ({ action, category, label, value = '' }: Event) => {
+  if (!existsGaId) {
+    return
+  }
+
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label ? JSON.stringify(label) : '',
+    value,
+  })
+}
+
+// _app.tsx で読み込む
+export const usePageView = () => {
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!existsGaId) {
+      return
+    }
+
+    const handleRouteChange = (path: string) => {
+      pageview(path)
+    }
+
+    router.events.on('routeChangeComplete', handleRouteChange)
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange)
+    }
+  }, [router.events])
+}
+
+// _app.tsx で読み込む
+export const GoogleAnalytics = () => (
+  <>
+    {existsGaId && (
+      <>
+        <Script defer src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`} strategy="afterInteractive" />
+        <Script
+          defer
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());    
+              gtag('config', '${GA_ID}');
+            `,
+          }}
+          strategy="afterInteractive"
+        />
+      </>
+    )}
+  </>
+)
+
+// イベントを型で管理
+type ContactEvent = {
+  action: 'submit_form'
+  category: 'contact'
+}
+
+type ClickEvent = {
+  action: 'click'
+  category: 'other'
+}
+
+export type Event = (ContactEvent | ClickEvent) & {
+  label?: Record<string, string | number | boolean>
+  value?: string
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "unified": "10.1.2"
   },
   "devDependencies": {
+    "@types/gtag.js": "^0.0.11",
     "@types/node": "18.0.0",
     "@types/react": "18.0.14",
     "@types/react-dom": "18.0.5",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,10 @@
 import '@/styles/globals.css'
 
 import type { AppPropsWithLayout } from 'next/app'
+import { usePageView } from "@/lib/gtag";
 
 function MyApp({ Component, pageProps }: AppPropsWithLayout) {
+  usePageView()
   const getLayout = Component.getLayout ?? ((page) => page)
   return getLayout(<Component {...pageProps} />)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -313,6 +313,11 @@
   dependencies:
     "@types/ms" "*"
 
+"@types/gtag.js@^0.0.11":
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.11.tgz#0c384ea32e4e40043a2dca82db79b5e48d681ad5"
+  integrity sha512-rUuSDedDjcuUpoc2zf6eX6zRrxqALNgwrmMBfVFopkLH7YGM52C7tt6j9GsYIvaxn+ioVRpOKoHnN1DXzHEqIg==
+
 "@types/hast@^2.0.0":
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.4.tgz#8aa5ef92c117d20d974a82bdfb6a648b08c0bafc"


### PR DESCRIPTION
GoogleAnalyticsでアクセスデータを収集できるようにしました。
ref: #8 

## 確認事項
- [ ] 各ページごとにアクセスがきちんとカウントされること。

## 確認方法
以下の手順に従って`G-`から始まる測定IDを手に入れてください。
https://support.google.com/analytics/answer/9304153

手に入れた測定IDを`config.ts`に書くと計測できます。
（http://localhost:3000 で実行しても計測できます）

<img width="1253" alt="スクリーンショット 2022-09-04 16 49 05" src="https://user-images.githubusercontent.com/38904644/188303259-72c9427d-a2bc-41bd-9029-9aa3ee7b563e.png">

# 注意点
GA4のデフォルトのデータ保存期間は2ヶ月らしい。
設定で14ヶ月まで伸ばせるのでとりあえず伸ばしておくのがいいと思う。
https://bop-com.co.jp/column/11374